### PR TITLE
Enable to pass maxage=0

### DIFF
--- a/lib/Log/LTSV/Instance.pm
+++ b/lib/Log/LTSV/Instance.pm
@@ -33,7 +33,7 @@ sub new {
     } else {
         my $rotatelogs = File::RotateLogs->new(
             logfile      => $args{logfile},
-            $args{maxage} ? ( maxage => $args{maxage} ) : (),
+            defined $args{maxage} ? ( maxage => $args{maxage} ) : (),
             $args{linkname} ? ( linkname     => $args{linkname} ) : (),
             $args{rotationtime} ? ( rotationtime => $args{rotationtime} ) : (),
         );


### PR DESCRIPTION
`maxage => 0` を指定しても File:: RotateLogs に渡されず、File:: RotateLogs が warn を出していました。
